### PR TITLE
feat: cast uin128 safely, fix `readyTime` in events across the board …

### DIFF
--- a/tests/test_after_call_disputed.py
+++ b/tests/test_after_call_disputed.py
@@ -25,7 +25,7 @@ def test_veto_passed(timelock, supremecourt, dispute_operation):
     id, _ = dispute_operation
 
     ACCEPT_VETO = 0
-    timelock.callDisputeResolve(id, ACCEPT_VETO, "", {"from": supremecourt})
+    timelock.callDisputeResolve(id, ACCEPT_VETO, "# Agree!", {"from": supremecourt})
 
     # Operation should be cancelled
     assert timelock.isOperation(id) == False
@@ -36,6 +36,6 @@ def test_veto_failed(timelock, supremecourt, dispute_operation):
     id, _ = dispute_operation
 
     REJECT_VETO = 1
-    timelock.callDisputeResolve(id, REJECT_VETO, "", {"from": supremecourt})
+    timelock.callDisputeResolve(id, REJECT_VETO, "# Disagree!", {"from": supremecourt})
 
     assert timelock.getDisputeStatus(id) == 2

--- a/tests/test_cancel_operation.py
+++ b/tests/test_cancel_operation.py
@@ -3,7 +3,7 @@ from brownie import reverts
 
 def test_cancel_operation(timelock, schedule_operation, cancellor):
     id = schedule_operation
-    tx = timelock.cancel(id, {"from": cancellor})
+    tx = timelock.cancel(id, "# Concerning tx!!", {"from": cancellor})
 
     cancel_event = tx.events["Cancelled"]
     assert len(cancel_event) > 0
@@ -14,7 +14,7 @@ def test_cancel_operation(timelock, schedule_operation, cancellor):
 
 def test_cancel_invalidad_operation(timelock, cancellor):
     with reverts("TimelockController: operation cannot be cancelled"):
-        timelock.cancel("0x", {"from": cancellor})
+        timelock.cancel("0x", "# Concerning tx!!", {"from": cancellor})
 
 
 def test_cancel_no_auth(timelock, schedule_operation, accounts):
@@ -23,4 +23,4 @@ def test_cancel_no_auth(timelock, schedule_operation, accounts):
 
     revert_msg = f"AccessControl: account {accounts[7].address.lower()} is missing role {CANCELLOR_ROLE}"
     with reverts(revert_msg):
-        timelock.cancel(id, {"from": accounts[7]})
+        timelock.cancel(id, "# Concerning tx!!", {"from": accounts[7]})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,7 +34,9 @@ def test_execute_after_dispute(
 
     # received supereme court judgement as reject
     SUPREME_COURT_REJECT = 1
-    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
+    timelock.callDisputeResolve(
+        id, SUPREME_COURT_REJECT, "# Disagree!", {"from": supremecourt}
+    )
 
     # check the operation should not be disputed now
     assert timelock.getDisputeStatus(id) == 2
@@ -65,7 +67,9 @@ def test_pause_after_veto_failed(
 
     # received supereme court judgement as reject
     SUPREME_COURT_REJECT = 1
-    timelock.callDisputeResolve(id, SUPREME_COURT_REJECT, "", {"from": supremecourt})
+    timelock.callDisputeResolve(
+        id, SUPREME_COURT_REJECT, "# Disagree!", {"from": supremecourt}
+    )
     # check the operation should not be disputed now
     assert timelock.getDisputeStatus(id) == 2
 
@@ -116,4 +120,19 @@ def test_execution_with_predecessor(
             predecessor_id,
             random_second_operation.salt,
             {"from": executor},
+        )
+
+
+def test_overflow_delay(timelock, random_operation, proposer):
+    MAX_UINT_128 = 2**128 - 1
+    with reverts("TimelockController: value doesn't fit in 128 bits"):
+        timelock.schedule(
+            random_operation.target,
+            random_operation.value,
+            random_operation.data,
+            random_operation.predecessor,
+            random_operation.salt,
+            MAX_UINT_128 + 1,
+            random_operation.description,
+            {"from": proposer},
         )


### PR DESCRIPTION
Resolves notes provided by @GalloDaSballo and @shuklaayush:

 - unsafe casting uint128

- properly timestamp in events for `readyTime`

- removes redundant event in `callDisputeResolve` given that it is either emitting *cancelled* or *rejected* events already

 - include extra argument in *cancelled* & *rejected* event as string to provide reasoning of why either was selected and triggered for on-chain footprint